### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # NSCLC-immunotherapy
 The scripts are used to analyze single cell RNA sequencing data in the paper "Tumor Microenvironment Remodeling after Neoadjuvant Immunotherapy in Non-small Cell Lung Cancer Revealed by Single-Cell RNA Sequencing", https://genomemedicine.biomedcentral.com/articles/10.1186/s13073-023-01164-9, including quality control, clustering, CopyKat, trajectory, CellPhoneDB, Nichenet, and SCENIC analyses.
-The scripts need modification accroding to the comments(##) in the script before running.
+The scripts need modification according to the comments(##) in the script before running.


### PR DESCRIPTION
## Summary
- correct a typo in README "accroding" -> "according"

## Testing
- `grep -n accroding -r README.md`

------
https://chatgpt.com/codex/tasks/task_e_6840733939348330a70168d098a91234